### PR TITLE
Fix ROOT comment

### DIFF
--- a/2. Structured Input/Structured Input Creator.py
+++ b/2. Structured Input/Structured Input Creator.py
@@ -45,7 +45,7 @@ def _collect_keys(schema: Dict[str, Any], chain: Tuple[str, ...] = ()) -> Dict[s
 
 # Base paths
 SCRIPT_DIR = Path(__file__).resolve().parent
-ROOT = SCRIPT_DIR.parent          # project root two levels up
+ROOT = SCRIPT_DIR.parent          # project root one level up
 SCHEMA_PATH = ROOT / "0. Config" / SCHEMA_FILE
 
 schema = _load_schema(SCHEMA_PATH)


### PR DESCRIPTION
## Summary
- correct the comment explaining the ROOT path in Structured Input Creator

## Testing
- `pytest -q` *(fails: no tests present)*

------
https://chatgpt.com/codex/tasks/task_e_686bec09f6f483209d99bc3bfc43fb7f