### PR TITLE
Add CI and tests, format script

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 79
+exclude = */pandoc-3.7.0.2-windows-x86_64.msi,0.*,*1.*,*3.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install flake8 pytest
+      - name: Lint
+        run: flake8
+      - name: Test
+        run: pytest -q

--- a/2. Structured Input/Structured Input Creator.py
+++ b/2. Structured Input/Structured Input Creator.py
@@ -3,8 +3,8 @@
 Structured Input Creator — strict-schema v1.2
 ============================================
 *   Keeps **only** keys present in `Structured_Input_scheme.json`.
-*   De‑duplicates each `rendering_positions` list, preserving **one** copy of each
-    unique block (no more repeats).
+*   De‑duplicates each `rendering_positions` list, preserving **one**
+    copy of each unique block (no more repeats).
 *   Safe against `null` → falls back to blanks/dicts.
 """
 from __future__ import annotations
@@ -22,6 +22,7 @@ ALGO_NAME = "Therapixel MammoScreen"
 # Schema helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def _load_schema(path: Path) -> Dict[str, Any]:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
@@ -29,7 +30,9 @@ def _load_schema(path: Path) -> Dict[str, Any]:
         sys.exit(f"[ERROR] Cannot read schema {path}: {e}")
 
 
-def _collect_keys(schema: Dict[str, Any], chain: Tuple[str, ...] = ()) -> Dict[str, Set[str]]:
+def _collect_keys(
+    schema: Dict[str, Any], chain: Tuple[str, ...] = ()
+) -> Dict[str, Set[str]]:
     """Return mapping { dotted_path : set(child_keys) }."""
     out: Dict[str, Set[str]] = {}
     for k, v in schema.items():
@@ -43,15 +46,18 @@ def _collect_keys(schema: Dict[str, Any], chain: Tuple[str, ...] = ()) -> Dict[s
             out.update(_collect_keys(v[0], new_chain))
     return out
 
+
 # Base paths
 SCRIPT_DIR = Path(__file__).resolve().parent
-ROOT = SCRIPT_DIR.parent          # project root one level up
+ROOT = SCRIPT_DIR.parent  # project root one level up
 SCHEMA_PATH = ROOT / "0. Config" / SCHEMA_FILE
 
 schema = _load_schema(SCHEMA_PATH)
 keymap = _collect_keys(schema)
 
-TOP_KEYS = {k for k, v in schema.items() if not isinstance(v, (dict, list))} | {"prior", "views", "findings"}
+TOP_KEYS = {
+    k for k, v in schema.items() if not isinstance(v, (dict, list))
+} | {"prior", "views", "findings"}
 PRIOR_KEYS = keymap.get("prior", set())
 VIEW_KEYS = keymap.get("views", set())
 FIND_KEYS = keymap.get("findings", set())
@@ -61,12 +67,24 @@ RENDER_KEYS = keymap.get("findings.rendering_positions", set())
 # Utility
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def _max_score(findings: List[Dict[str, Any]], side: str) -> int:
-    return max((f.get("mammoscreen_score", 0) for f in findings if f.get("laterality") == side), default=0)
+    return max(
+        (
+            f.get("mammoscreen_score", 0)
+            for f in findings
+            if f.get("laterality") == side
+        ),
+        default=0,
+    )
 
 
 def _laterality(has_left: bool, has_right: bool) -> str:
-    return "B" if has_left and has_right else "L" if has_left else "R" if has_right else ""
+    return (
+        "B"
+        if has_left and has_right
+        else "L" if has_left else "R" if has_right else ""
+    )
 
 
 def _filter(d: Dict[str, Any], allowed: Set[str]) -> Dict[str, Any]:
@@ -91,9 +109,11 @@ def _dedup(list_of_dicts: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             uniq.append(item)
     return uniq
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Core conversion
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _convert_record(raw: Dict[str, Any]) -> Dict[str, Any]:
     findings_raw = raw.get("findings", [])
@@ -101,14 +121,17 @@ def _convert_record(raw: Dict[str, Any]) -> Dict[str, Any]:
     left_score = _max_score(findings_raw, "LEFT")
     right_score = _max_score(findings_raw, "RIGHT")
 
-    out = {k: raw.get(k, "") for k in TOP_KEYS if k not in {"prior", "views", "findings"}}
+    out = {
+        k: raw.get(k, "")
+        for k in TOP_KEYS
+        if k not in {"prior", "views", "findings"}
+    }
     out.setdefault("manufacturer", ALGO_NAME)
     out["left_mammoscreen_score"] = left_score
     out["right_mammoscreen_score"] = right_score
     out["laterality"] = _laterality(bool(left_score), bool(right_score))
 
     # prior
-
 
     prior_src = raw.get("prior") or {}
 
@@ -120,7 +143,6 @@ def _convert_record(raw: Dict[str, Any]) -> Dict[str, Any]:
             v = ""
         prior_norm[k] = v
 
-
     out["prior"] = prior_norm
 
     # views
@@ -130,16 +152,20 @@ def _convert_record(raw: Dict[str, Any]) -> Dict[str, Any]:
     norm_findings: List[Dict[str, Any]] = []
     for f in findings_raw:
         nf = _filter(f, FIND_KEYS)
-        rp_filtered = [_filter(rp, RENDER_KEYS) for rp in f.get("rendering_positions", [])]
+        rp_filtered = [
+            _filter(rp, RENDER_KEYS) for rp in f.get("rendering_positions", [])
+        ]
         nf["rendering_positions"] = _dedup(rp_filtered)
         norm_findings.append(nf)
     out["findings"] = norm_findings
 
     return out
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 # I/O helpers
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _out_name(src: Path) -> str:
     return f"{src.stem} Structured Input{src.suffix}"
@@ -149,12 +175,16 @@ def _process_file(src: Path, dst_dir: Path) -> None:
     structured = _convert_record(json.loads(src.read_text(encoding="utf-8")))
     dst_dir.mkdir(parents=True, exist_ok=True)
     dst = dst_dir / _out_name(src)
-    dst.write_text(json.dumps(structured, indent=2, ensure_ascii=False), encoding="utf-8")
+    dst.write_text(
+        json.dumps(structured, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     print(f"✔ {src.name} → {dst.relative_to(dst_dir.parent)}")
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Bulk
 # ─────────────────────────────────────────────────────────────────────────────
+
 
 def _bulk(inp: Path, out: Path) -> None:
     if not inp.exists():
@@ -165,15 +195,33 @@ def _bulk(inp: Path, out: Path) -> None:
     for src in files:
         _process_file(src, out)
 
+
 # ─────────────────────────────────────────────────────────────────────────────
 # CLI
 # ─────────────────────────────────────────────────────────────────────────────
 
+
 def main() -> None:
-    p = argparse.ArgumentParser("Convert MammoScreen JSONs to strict Structured Input schema",
-                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    p.add_argument("-i", "--in", dest="inp", type=Path, default=ROOT / "1. Input", help="Raw JSON folder")
-    p.add_argument("-o", "--out", dest="out", type=Path, default=ROOT / "2. Structured Input", help="Output folder")
+    p = argparse.ArgumentParser(
+        "Convert MammoScreen JSONs to strict Structured Input schema",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "-i",
+        "--in",
+        dest="inp",
+        type=Path,
+        default=ROOT / "1. Input",
+        help="Raw JSON folder",
+    )
+    p.add_argument(
+        "-o",
+        "--out",
+        dest="out",
+        type=Path,
+        default=ROOT / "2. Structured Input",
+        help="Output folder",
+    )
     args = p.parse_args()
     _bulk(args.inp, args.out)
 

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -1,0 +1,66 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "2. Structured Input"
+    / "Structured Input Creator.py"
+)
+
+spec = importlib.util.spec_from_file_location("creator", MODULE_PATH)
+creator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(creator)
+
+
+def test_filter():
+    allowed = {"a"}
+    assert creator._filter({"a": None}, allowed) == {"a": ""}
+    assert creator._filter({"a": 5}, allowed) == {"a": 5}
+    assert creator._filter({"b": "x"}, allowed) == {}
+
+
+def test_convert_record_basic():
+    raw = {
+        "patient_name": "Alice",
+        "patient_dob": None,
+        "prior": {"study_date": None},
+        "views": [
+            {
+                "laterality": "LEFT",
+                "breast_side": "L",
+                "patient_orientation_x": "x",
+                "patient_orientation_y": "y",
+                "flip_h": True,
+                "flip_v": False,
+                "flip_slice": None,
+                "view_position": "CC",
+                "number_of_frames": 1,
+                "direction": None,
+                "image_modality": "mammo",
+            }
+        ],
+        "findings": [
+            {
+                "mammoscreen_score": 3,
+                "laterality": "LEFT",
+                "rendering_positions": [{"finding_size_mm": 12}],
+                "depth": "anterior",
+                "suspicion_level": "high",
+                "quadrant": "upper",
+                "evolution": "new",
+                "type": "mass",
+                "with_calcis": False,
+            }
+        ],
+    }
+
+    result = creator._convert_record(raw)
+    # None values should not cause errors
+    assert result["prior"]["study_date"] in ("", None)
+    # numeric fields preserved
+    assert (
+        result["findings"][0]["rendering_positions"][0]["finding_size_mm"]
+        == 12
+    )
+    # missing keys still present in output
+    assert "patient_dob" in result


### PR DESCRIPTION
## Summary
- format "Structured Input Creator.py" with line length 79
- add flake8 configuration and CI workflow
- create unit tests for `_filter` and `_convert_record`

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686befd87c0c83208e4ccc6e4e6d96eb