### PR TITLE
Fix generator to ensure output directories exist

### DIFF
--- a/3. Report Generator/c. Generator/cli.py
+++ b/3. Report Generator/c. Generator/cli.py
@@ -19,6 +19,7 @@ def main() -> None:
     case = json.loads(args.inp.read_text(encoding="utf-8"))
     prompt_path, templates = select_for_case(case)
     report = generate_report(case, prompt_path, templates)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(report, encoding="utf-8")
     print(f"✔ Saved report → {args.out}")
 


### PR DESCRIPTION
## Summary
- create parent directories in the report generator CLI before writing reports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c009af36083208a2320940a0ae439