### PR TITLE
Add batch report generation

### DIFF
--- a/3. Report Generator/c. Generator/batch_cli.py
+++ b/3. Report Generator/c. Generator/batch_cli.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Batch report generator for all structured input cases."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .select_assets import select_for_case
+from .jinja_renderer import generate_reports
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        description="Generate clinical reports for all structured inputs",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "-i",
+        "--input",
+        dest="inp",
+        type=Path,
+        default=ROOT / "2. Structured Input",
+        help="Folder of structured input JSON files",
+    )
+    p.add_argument(
+        "-o",
+        "--out",
+        dest="out",
+        type=Path,
+        default=ROOT / "3. Report Generator" / "d. Tests",
+        help="Destination folder for generated reports",
+    )
+    args = p.parse_args()
+
+    files = sorted(args.inp.glob("*.json"))
+    if not files:
+        p.error(f"No .json files found in {args.inp}")
+
+    for src in files:
+        case = json.loads(src.read_text(encoding="utf-8"))
+        prompt_path, templates = select_for_case(case)
+        reports = generate_reports(case, prompt_path, templates)
+        case_dir = args.out / src.stem
+        case_dir.mkdir(parents=True, exist_ok=True)
+        for t in templates:
+            out_path = case_dir / f"{t.stem}.md"
+            out_path.write_text(reports[t.stem], encoding="utf-8")
+        print(f"✔ {src.name} → {case_dir.relative_to(args.out)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/3. Report Generator/c. Generator/jinja_renderer.py
+++ b/3. Report Generator/c. Generator/jinja_renderer.py
@@ -65,9 +65,25 @@ def render_template(template_text: str, context: Dict[str, Any]) -> str:
     return Template(template_text).render(**context)
 
 
-def generate_report(structured: Dict[str, Any], prompt_path: Path, template_paths: List[Path]) -> str:
+def generate_reports(
+    structured: Dict[str, Any],
+    prompt_path: Path,
+    template_paths: List[Path],
+) -> Dict[str, str]:
+    """Return rendered reports for all templates."""
     prompt = prompt_path.read_text(encoding="utf-8")
     templates = [p.read_text(encoding="utf-8") for p in template_paths]
     context = query_gemini(structured, prompt, templates)
-    # Use first template for now
-    return render_template(templates[0], context)
+    return {
+        p.stem: render_template(t_text, context)
+        for p, t_text in zip(template_paths, templates)
+    }
+
+
+def generate_report(
+    structured: Dict[str, Any],
+    prompt_path: Path,
+    template_paths: List[Path],
+) -> str:
+    reports = generate_reports(structured, prompt_path, template_paths)
+    return reports[next(iter(reports))]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ python "2. Structured Input/Structured Input Creator.py"        "1. Input/Therap
 
 # 6  Generate the clinical report
 python "3. Report Generator/c. Generator/cli.py"        -i "2. Structured Input/Therapixel - Case 1 Test Structured Input.json"        -o "4. Reports/Case1_report.md"
+# 7  Generate reports for all test cases
+python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Generator/d. Tests"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- support rendering of all templates via `generate_reports`
- expose a `batch_cli.py` script to create reports for every structured input
- document batch script usage in README

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c09e4b90c8320b019ff4c898b1a44