### PR TITLE
Update pipeline for direct Gemini output

### DIFF
--- a/3. Report Generator/b. Templates/convert_docx_to_txt.py
+++ b/3. Report Generator/b. Templates/convert_docx_to_txt.py
@@ -59,25 +59,13 @@ USE_ATX = supports_atx_headers()
 PLACEHOLDER_RE = re.compile(r"\\?\[([^\]\n]+)\]")
 
 
-def _slugify(text: str) -> str:
-    return re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
 
 
 def _convert_placeholders(text: str) -> str:
-    """
-    Replace [PLACEHOLDER] with Jinja {{ placeholder }}.
-    • Keeps complex tags like [Dose (mGy)/kg] unchanged.
-    • Removes Pandoc’s escaping back-slash if present.
-    """
-    # Rendering step: jinja_template.render(context) must replace all
-    # {{ placeholder }} before the clinician sees the report.
+    """Return text with placeholders untouched (remove escape backslashes)."""
 
     def repl(match: re.Match) -> str:
-        raw = match.group(0).lstrip("\\")          # kill leading back-slash
-        label = match.group(1).strip()
-        if any(sep in label for sep in ("/", "|", ";")):
-            return raw                              # leave complex labels verbatim
-        return f"{{{{ {_slugify(label)} }}}}"       # simple → Jinja
+        return match.group(0).lstrip("\\")
 
     return PLACEHOLDER_RE.sub(repl, text)
 

--- a/3. Report Generator/c. Generator/batch_cli.py
+++ b/3. Report Generator/c. Generator/batch_cli.py
@@ -8,14 +8,14 @@ from pathlib import Path
 
 try:  # When executed as part of a package
     from .select_assets import select_for_case
-    from .jinja_renderer import generate_reports
+    from .gemini_reporter import generate_reports
 except ImportError:  # Fallback when run as a standalone script
     from pathlib import Path
     import sys
 
     sys.path.append(str(Path(__file__).resolve().parent))
     from select_assets import select_for_case
-    from jinja_renderer import generate_reports
+    from gemini_reporter import generate_reports
 
 ROOT = Path(__file__).resolve().parents[2]
 

--- a/3. Report Generator/c. Generator/cli.py
+++ b/3. Report Generator/c. Generator/cli.py
@@ -8,14 +8,14 @@ from pathlib import Path
 
 try:  # When executed as part of a package
     from .select_assets import select_for_case
-    from .jinja_renderer import generate_report
+    from .gemini_reporter import generate_report
 except ImportError:  # Fallback when run as a standalone script
     from pathlib import Path
     import sys
 
     sys.path.append(str(Path(__file__).resolve().parent))
     from select_assets import select_for_case
-    from jinja_renderer import generate_report
+    from gemini_reporter import generate_report
 
 
 def main() -> None:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 | **Step 0 – Config** | Central location for schema & tuning knobs | Single‑source YAML files |
 | **Step 1 – Input** | Stores raw vendor dumps for audit | Zero mutation of originals |
 | **Step 2 – Structured Input** | Normalises diverse vendor JSON into a strict schema | `Structured Input Creator.py` auto‑fills mandatory keys |
-| **Step 3 – Report Generator** | <ul><li>Selects the right prompt + template</li><li>Calls Gemini (Google Generative AI)</li><li>Renders Jinja → plain text (or DOCX)</li></ul> | • Hot‑swappable prompts  <br>• Clinician‑editable templates |
+| **Step 3 – Report Generator** | <ul><li>Selects the right prompt + template</li><li>Calls Gemini (Google Generative AI)</li><li>Outputs Markdown reports</li></ul> | • Hot‑swappable prompts  <br>• Clinician‑editable templates |
 | **Cross‑cutting** | Tests, helper CLIs, Pandoc utilities | Works on Windows / macOS / Linux |
 
 ---
@@ -54,7 +54,7 @@ repo-root/
     ├── c. Generator/
     │   ├── __init__.py
     │   ├── cli.py
-    │   ├── jinja_renderer.py
+    │   ├── gemini_reporter.py
     │   └── select_assets.py
 ```
 
@@ -99,13 +99,12 @@ python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Gene
 * a system prompt (`a. Prompts/…`)
 * a text template (`b. Templates/Text/…`)
 
-### 3️⃣  Call Gemini  
-`jinja_renderer.py` sends the full structured JSON as *user* content, with the modality‑specific prompt as *system* instruction.  
-The prompt tells Gemini to reply with a compact JSON payload (`patient_name`, `birads`, etc.).
+### 3️⃣  Call Gemini
+`gemini_reporter.py` sends the structured JSON and template snippets to Gemini.
+The model replies with a complete Markdown report ready for clinicians.
 
-### 4️⃣  Render via Jinja  
-Jinja2 merges the LLM payload into the chosen template → plain text.
-Need DOCX? Simply run Pandoc:
+### 4️⃣  (Optional) Convert to DOCX
+If needed, Jinja or Pandoc can reformat the Markdown into a DOCX report:
 
 ```bash
 pandoc report.md -o report.docx   --reference-doc="3. Report Generator/b. Templates/DOCX Source/reference.docx"

--- a/tests/test_convert_docx.py
+++ b/tests/test_convert_docx.py
@@ -40,4 +40,4 @@ def test_convert_writes_file(monkeypatch, tmp_path):
     txt = tmp_path / "out.txt"
     convert(docx, txt)
     assert txt.exists()
-    assert txt.read_text(encoding="utf-8") == "Age: {{ age }}\n"
+    assert txt.read_text(encoding="utf-8") == "Age: [Age]\n"

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -1,53 +1,28 @@
 import importlib.util
 from pathlib import Path
 
-# Dynamically import jinja_renderer
+# Dynamically import gemini_reporter
 GEN_DIR = (
     Path(__file__).resolve().parents[1]
     / "3. Report Generator"
     / "c. Generator"
 )
-MOD_PATH = GEN_DIR / "jinja_renderer.py"
+MOD_PATH = GEN_DIR / "gemini_reporter.py"
 spec = importlib.util.spec_from_file_location("renderer", MOD_PATH)
 renderer = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(renderer)
 
 
-class DummyTemplate:
-    def __init__(self, text):
-        self.text = text
-
-    def render(self, **ctx):
-        return self.text.format(**ctx)
-
-
 def common_setup(monkeypatch):
     monkeypatch.setattr(renderer, "_load_config", lambda: {})
-    monkeypatch.setattr(renderer, "Template", DummyTemplate)
 
 
-def test_generate_reports_render(monkeypatch, tmp_path):
+def test_generate_reports(monkeypatch, tmp_path):
     common_setup(monkeypatch)
     monkeypatch.setattr(
         renderer,
         "query_gemini",
-        lambda structured, prompt, templates: {"name": "Alice"},
-    )
-    prompt = tmp_path / "p.txt"
-    prompt.write_text("prompt")
-    template = tmp_path / "t.txt"
-    template.write_text("Hello {name}")
-
-    result = renderer.generate_reports({}, prompt, [template])
-    assert result == {"t": "Hello Alice"}
-
-
-def test_generate_reports_passthrough(monkeypatch, tmp_path):
-    common_setup(monkeypatch)
-    monkeypatch.setattr(
-        renderer,
-        "query_gemini",
-        lambda *a, **k: {"report": "final"},
+        lambda *a, **k: "final",
     )
     prompt = tmp_path / "p.txt"
     prompt.write_text("prompt")

--- a/tests/test_placeholder_utils.py
+++ b/tests/test_placeholder_utils.py
@@ -25,5 +25,4 @@ _convert_placeholders = namespace["_convert_placeholders"]
 def test_placeholder_conversion():
     text = "Age : [Age]\nOption: [A / B]"
     out = _convert_placeholders(text)
-    assert "{{ age }}" in out
-    assert "[A / B]" in out
+    assert out == text

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,19 +1,18 @@
 import importlib.util
 from pathlib import Path
 
-# Dynamically import jinja_renderer
+# Dynamically import gemini_reporter
 GEN_DIR = (
     Path(__file__).resolve().parents[1]
     / "3. Report Generator"
     / "c. Generator"
 )
-MOD_PATH = GEN_DIR / "jinja_renderer.py"
+MOD_PATH = GEN_DIR / "gemini_reporter.py"
 spec = importlib.util.spec_from_file_location("renderer", MOD_PATH)
 renderer = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(renderer)
 
 
-def test_parse_response_invalid():
-    # Non-JSON input should be returned as a pre-rendered report
-    result = renderer._parse_response("not json")
-    assert result == {"report": "not json"}
+def test_parse_response_strips_reasoning():
+    text = "final\nReasoning: bla"
+    assert renderer._parse_response(text) == "final"


### PR DESCRIPTION
## Summary
- rename `jinja_renderer.py` to `gemini_reporter.py`
- simplify renderer to return Gemini Markdown directly
- keep placeholders intact when converting DOCX templates
- update CLI scripts, tests and docs
- clean up stray bytecode files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb4dced4083209f0761dfdbe7a24b