### PR TITLE
Fix missing json import in gemini_reporter

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import re
+import json
 from pathlib import Path
 from typing import Dict, List, Any
 


### PR DESCRIPTION
## Summary
- add json import to gemini_reporter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cbb947fb083208c31b17d2dcf58fc