### PR TITLE
Add JSON-to-Markdown rendering

### DIFF
--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -13,6 +13,11 @@ renderer = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(renderer)
 
 
-def test_parse_response_strips_reasoning():
-    text = "final\nReasoning: bla"
-    assert renderer._parse_response(text) == "final"
+def test_parse_response_json():
+    text = "```json\n{\n  \"lines\": [\"a\", \"b\"]\n}\n```\nReasoning: bla"
+    assert renderer._parse_response(text) == {"lines": ["a", "b"]}
+
+
+def test_render_json_to_md():
+    md = renderer.render_json_to_md({"lines": ["a", "b"]})
+    assert md == "a\nb\n"


### PR DESCRIPTION
## Summary
- parse Gemini JSON responses
- convert JSON line arrays to Markdown
- update tests for new rendering workflow

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc05ff7e88320be0f74ca7228301b