### PR TITLE
Update prompt output format

### DIFF
--- a/3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
+++ b/3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
@@ -114,4 +114,6 @@ prompt: |-
 
   - Infer the ACR/BIRADS classification from numeric scores (e.g. `mammoscreen_score`) and suspicion levels in the preliminary report. Do not merely copy these numeric values. The "mammoscreen_score" in your input JSON is NOT an ACR score (though it may be the same value), and must not appear in your output.
 
-  Return the final report as a JSON object with keys like `title`, `views`, `findings`, `conclusion`, and `birads`. Wrap the JSON in a fenced ```json block.
+  Return the final report as a JSON object with a single key `lines`.
+  The value must be a list of strings, each string representing one line of the final report.
+  Wrap the JSON in a fenced ```json block.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Gene
 
 ### 3️⃣  Call Gemini
 `gemini_reporter.py` sends the structured JSON and template snippets to Gemini.
-The model replies with a complete Markdown report ready for clinicians.
+The model replies with a JSON block containing a list of Markdown lines:
+`{"lines": ["..."]}`.
+`gemini_reporter.py` joins these lines into the final Markdown report ready for clinicians.
 
 ### 4️⃣  (Optional) Convert to DOCX
 If needed, Jinja or Pandoc can reformat the Markdown into a DOCX report:


### PR DESCRIPTION
## Summary
- clarify that Gemini output should be returned as a JSON block with a list of lines
- document this behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ce5234a288320be6fa877a4d2ae99