### PR TITLE
Add raw JSON export option

### DIFF
--- a/3. Report Generator/c. Generator/batch_cli.py
+++ b/3. Report Generator/c. Generator/batch_cli.py
@@ -41,6 +41,13 @@ def main() -> None:
         default=ROOT / "3. Report Generator" / "d. Tests",
         help="Destination folder for generated reports",
     )
+    p.add_argument(
+        "-j",
+        "--json-dir",
+        dest="json_dir",
+        type=Path,
+        help="Optional folder to store raw Gemini JSON responses",
+    )
     args = p.parse_args()
 
     files = sorted(args.inp.glob("*.json"))
@@ -50,9 +57,12 @@ def main() -> None:
     for src in files:
         case = json.loads(src.read_text(encoding="utf-8"))
         prompt_path, templates = select_for_case(case)
-        reports = generate_reports(case, prompt_path, templates)
         case_dir = args.out / src.stem
         case_dir.mkdir(parents=True, exist_ok=True)
+        json_dir = args.json_dir / src.stem if args.json_dir else None
+        reports = generate_reports(
+            case, prompt_path, templates, json_dir=json_dir
+        )
         for t in templates:
             out_path = case_dir / f"{t.stem}.md"
             out_path.write_text(reports[t.stem], encoding="utf-8")

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ python "2. Structured Input/Structured Input Creator.py"        "1. Input/Therap
 python "3. Report Generator/c. Generator/cli.py"        -i "2. Structured Input/Therapixel - Case 1 Test Structured Input.json"        -o "4. Reports/Case1_report.md"
 # 7  Generate reports for all test cases
 python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Generator/d. Tests"
+#   (optional) store raw JSON replies
+python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Generator/d. Tests"        -j "3. Report Generator/d. Tests/json"
 # Windows users: run each line separately (don't paste two commands on one line).
 ```
 

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -1,4 +1,5 @@
 import importlib.util
+import json
 from pathlib import Path
 
 # Dynamically import gemini_reporter
@@ -45,3 +46,23 @@ def test_generate_reports(monkeypatch, tmp_path):
     result = renderer.generate_reports({}, prompt, [t1, t2])
     assert result == {"a": "one", "b": "two"}
     assert calls == [["A {name}"], ["B {name}"]]
+
+
+def test_generate_reports_json_dir(monkeypatch, tmp_path):
+    common_setup(monkeypatch)
+    output = {"lines": ["x"]}
+
+    monkeypatch.setattr(renderer, "query_gemini", lambda *a: output)
+    monkeypatch.setattr(renderer, "render_json_to_md", lambda d: "res")
+
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("prompt")
+    t1 = tmp_path / "a.txt"
+    t1.write_text("T")
+    jdir = tmp_path / "json"
+
+    result = renderer.generate_reports({}, prompt, [t1], json_dir=jdir)
+
+    assert result == {"a": "res"}
+    saved = json.loads((jdir / "a.json").read_text())
+    assert saved == output


### PR DESCRIPTION
## Summary
- allow `gemini_reporter.generate_reports()` to save JSON outputs
- surface new `--json-dir` flag in `batch_cli.py`
- document optional JSON export in README
- test saving of JSON responses

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ceb1738248320a8b597c203e6a6f9