### PR TITLE
Fix duplicate CLI option in batch_cli

### DIFF
--- a/3. Report Generator/c. Generator/batch_cli.py
+++ b/3. Report Generator/c. Generator/batch_cli.py
@@ -49,13 +49,6 @@ def main() -> None:
         default=ROOT / "3. Report Generator" / "d. Gemini Output JSON",
         help="Folder to store raw Gemini JSON responses",
     )
-    p.add_argument(
-        "-j",
-        "--json-dir",
-        dest="json_dir",
-        type=Path,
-        help="Optional folder to store raw Gemini JSON responses",
-    )
     args = p.parse_args()
 
     files = sorted(args.inp.glob("*.json"))


### PR DESCRIPTION
## Summary
- remove duplicated `-j/--json-dir` argument from batch CLI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf0521a108320ad5b34b6c8a921fb