### PR TITLE
Fix batch CLI by restoring modality map

### DIFF
--- a/0. Config/modality_map.yaml
+++ b/0. Config/modality_map.yaml
@@ -1,0 +1,3 @@
+mammography:
+  prompt: 3. Report Generator/a. Prompts/Templator Prompt.yaml
+  templates: 3. Report Generator/b. Templates/Text

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ python "3. Report Generator/c. Generator/batch_cli.py"        -o "3. Report Gene
 * a system prompt (`a. Prompts/…`)
 * a text template (`b. Templates/Text/…`)
 
+This mapping file is required by the batch CLI; removing it will result in
+errors when generating reports.
+
 ### 3️⃣  Call Gemini
 `gemini_reporter.py` sends the structured JSON and template snippets to Gemini.
 The model replies with a JSON block containing a list of Markdown lines:
@@ -160,6 +163,8 @@ top_p: 0.1
 max_output_tokens: 6000
 prompt_file: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
 ```
+Only the fields shown above are currently consumed by the code. Other keys like
+`include_thoughts`, `thinking_budget` and `seed` are legacy and can be ignored.
 
 ---
 

--- a/tests/test_select_assets.py
+++ b/tests/test_select_assets.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "3. Report Generator"
+    / "c. Generator"
+    / "select_assets.py"
+)
+spec = importlib.util.spec_from_file_location("sel", MODULE_PATH)
+sel = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sel)
+
+
+def test_prompt_override(monkeypatch, tmp_path):
+    # Create mapping and config under temporary root
+    root = tmp_path
+    config_dir = root / "0. Config"
+    config_dir.mkdir()
+    map_file = config_dir / "modality_map.yaml"
+    map_file.write_text(
+        "mammography:\n  prompt: a.yaml\n  templates: templates",
+        encoding="utf-8",
+    )
+    cfg_file = config_dir / "query_configs.yaml"
+    cfg_file.write_text(
+        "prompt_file: override.yaml",
+        encoding="utf-8",
+    )
+    tmpl_dir = root / "templates"
+    tmpl_dir.mkdir()
+    t = tmpl_dir / "t.txt"
+    t.write_text("T", encoding="utf-8")
+
+    monkeypatch.setattr(sel, "ROOT", root)
+    monkeypatch.setattr(sel, "MAP_FILE", map_file)
+    monkeypatch.setattr(sel, "CONFIG_FILE", cfg_file)
+    monkeypatch.setattr(sel, "load_mapping", lambda path=map_file: sel.yaml.safe_load(map_file.read_text()))
+
+    case = {"views": [{"image_modality": "mammography"}]}
+    prompt, templates = sel.select_for_case(case)
+    assert prompt == root / "override.yaml"
+    assert templates == [t]


### PR DESCRIPTION
## Summary
- restore missing `modality_map.yaml` so batch CLI can run again
- document query config fields and warn about legacy keys
- mention that `modality_map.yaml` is required for batch runs
- add regression test proving that `query_configs.yaml` overrides mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d007572108320aeadb7f45195cdf0