### PR TITLE
Improve CLI UX with interactive prompts

### DIFF
--- a/3. Report Generator/c. Generator/batch_cli.py
+++ b/3. Report Generator/c. Generator/batch_cli.py
@@ -10,7 +10,6 @@ try:  # When executed as part of a package
     from .select_assets import select_for_case
     from .gemini_reporter import generate_reports
 except ImportError:  # Fallback when run as a standalone script
-    from pathlib import Path
     import sys
 
     sys.path.append(str(Path(__file__).resolve().parent))
@@ -56,6 +55,7 @@ def main() -> None:
         p.error(f"No .json files found in {args.inp}")
 
     for src in files:
+        print(f"\nProcessing {src.name}…")
         case = json.loads(src.read_text(encoding="utf-8"))
         prompt_path, templates = select_for_case(case)
         case_dir = args.out / src.stem
@@ -67,7 +67,8 @@ def main() -> None:
         for t in templates:
             out_path = case_dir / f"{t.stem}.md"
             out_path.write_text(reports[t.stem], encoding="utf-8")
-        print(f"✔ {src.name} → {case_dir.relative_to(args.out)}")
+            print(f"  ✔ saved {out_path.relative_to(args.out)}")
+        print(f"✔ Completed {src.name}\n")
 
 
 if __name__ == "__main__":

--- a/3. Report Generator/c. Generator/cli.py
+++ b/3. Report Generator/c. Generator/cli.py
@@ -10,7 +10,6 @@ try:  # When executed as part of a package
     from .select_assets import select_for_case
     from .gemini_reporter import generate_report
 except ImportError:  # Fallback when run as a standalone script
-    from pathlib import Path
     import sys
 
     sys.path.append(str(Path(__file__).resolve().parent))
@@ -19,14 +18,76 @@ except ImportError:  # Fallback when run as a standalone script
 
 
 def main() -> None:
-    p = argparse.ArgumentParser(description="Generate clinical report from structured input")
-    p.add_argument("-i", "--input", dest="inp", type=Path, required=True, help="Structured input JSON")
-    p.add_argument("-o", "--output", dest="out", type=Path, required=True, help="Output Markdown file")
+    p = argparse.ArgumentParser(
+        description="Generate clinical report from structured input",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "-i",
+        "--input",
+        dest="inp",
+        type=Path,
+        help="Structured input JSON",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        dest="out",
+        type=Path,
+        help="Output Markdown file",
+    )
+    p.add_argument(
+        "-t",
+        "--template",
+        dest="template",
+        type=Path,
+        help="Template text file",
+    )
     args = p.parse_args()
+
+    root = Path(__file__).resolve().parents[2]
+
+    if args.inp is None:
+        default_dir = root / "2. Structured Input"
+        files = sorted(default_dir.glob("*.json"))
+        if not files:
+            p.error(f"No .json files found in {default_dir}")
+        print("Select structured input:")
+        for i, f in enumerate(files, 1):
+            print(f"{i}) {f.name}")
+        while True:
+            choice = input("Enter number: ")
+            if choice.isdigit() and 1 <= int(choice) <= len(files):
+                args.inp = files[int(choice) - 1]
+                break
+            print("Invalid selection")
 
     case = json.loads(args.inp.read_text(encoding="utf-8"))
     prompt_path, templates = select_for_case(case)
-    report = generate_report(case, prompt_path, templates)
+
+    if args.template is None:
+        print("Select template:")
+        for i, t in enumerate(templates, 1):
+            print(f"{i}) {t.name}")
+        while True:
+            choice = input("Enter number: ")
+            if choice.isdigit() and 1 <= int(choice) <= len(templates):
+                args.template = templates[int(choice) - 1]
+                break
+            print("Invalid selection")
+    else:
+        args.template = Path(args.template)
+
+    if args.out is None:
+        out_dir = (
+            root
+            / "3. Report Generator"
+            / "e. Final Report"
+            / args.inp.stem
+        )
+        args.out = out_dir / f"{Path(args.template).stem}.md"
+
+    report = generate_report(case, prompt_path, [args.template])
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(report, encoding="utf-8")
     print(f"✔ Saved report → {args.out}")


### PR DESCRIPTION
## Summary
- add per-file progress messages in batch_cli
- allow interactive selection of input and template in cli

## Testing
- `flake8 3.\ Report\ Generator/c.\ Generator/cli.py`
- `flake8 3.\ Report\ Generator/c.\ Generator/batch_cli.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d0c59b2d483209b283d30e00e2f91