### PR TITLE
fix: tidy heading spacing in docx conversion

### DIFF
--- a/tests/test_heading_utils.py
+++ b/tests/test_heading_utils.py
@@ -1,0 +1,29 @@
+import re
+from pathlib import Path
+
+MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "3. Report Generator"
+    / "b. Templates"
+    / "convert_docx_to_md.py"
+)
+source = MODULE.read_text(encoding="utf-8")
+
+snippet = re.search(
+    (
+        r"HEADING_RE.*?def _normalize_headings.*?"
+        r"return \"\\n\".join\(out\) \+ \"\\n\""
+    ),
+    source,
+    re.S,
+).group()
+
+namespace = {"re": re}
+exec(snippet, namespace)
+_normalize_headings = namespace["_normalize_headings"]
+
+
+def test_normalize_headings_basic():
+    text = "# H1\n\n\nPara\n\n## H2\n\nText\n"
+    out = _normalize_headings(text)
+    assert out == "# H1\nPara\n\n## H2\nText\n"

--- a/tests/test_select_assets.py
+++ b/tests/test_select_assets.py
@@ -35,13 +35,13 @@ def test_prompt_override(monkeypatch, tmp_path):
     monkeypatch.setattr(sel, "ROOT", root)
     monkeypatch.setattr(sel, "MAP_FILE", map_file)
     monkeypatch.setattr(sel, "CONFIG_FILE", cfg_file)
+    import yaml
+    monkeypatch.setattr(sel, "yaml", yaml)
     monkeypatch.setattr(
-    sel,
-    "load_mapping",
-    lambda path=map_file: sel.yaml.safe_load(
-        map_file.read_text()
+        sel,
+        "load_mapping",
+        lambda path=map_file: sel.yaml.safe_load(map_file.read_text()),
     )
-)
 
     case = {"views": [{"image_modality": "mammography"}]}
     prompt, templates = sel.select_for_case(case)


### PR DESCRIPTION
## Summary
- ensure Markdown headings have consistent spacing during DOCX conversion
- squeeze extra blank lines
- add test covering heading normalization
- address flake8 issues in tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d335bdde08320a8935aa4d7fd6d8d