### PR TITLE
Promote bold lines to Markdown headings

### DIFF
--- a/3. Report Generator/b. Templates/convert_docx_to_md.py
+++ b/3. Report Generator/b. Templates/convert_docx_to_md.py
@@ -79,6 +79,22 @@ def _convert_placeholders(text: str) -> str:
 
     return PLACEHOLDER_RE.sub(repl, text)
 
+# ── Promote ad-hoc bold headings (e.g. '**CONCLUSION**') ─────────────
+BOLD_HEADING_RE = re.compile(r'^\*\*(.+?)\*\*(?:\\)?\s*$')
+
+
+def _promote_bold_headings(text: str) -> str:
+    """Turn lines that consist solely of bold text into level-2 Markdown headings."""
+
+    out = []
+    for ln in text.splitlines():
+        m = BOLD_HEADING_RE.match(ln.strip())
+        if m:
+            out.append('## ' + m.group(1).strip())
+        else:
+            out.append(ln)
+    return '\n'.join(out)
+
 # ── Keep heading spacing tidy ────────────────────────────────────────────────
 HEADING_RE = re.compile(r"^#{1,6}\s")
 
@@ -128,6 +144,7 @@ def convert(docx: Path, md: Path) -> None:
             cmd, check=True, capture_output=True, text=True, encoding="utf-8"
         )
         text = _convert_placeholders(result.stdout)
+        text = _promote_bold_headings(text)
         text = _cleanup_blank_lines(text)
         text = _normalize_headings(text)
         text = re.sub(r"\n{3,}", "\n\n", text)

--- a/tests/test_heading_utils.py
+++ b/tests/test_heading_utils.py
@@ -10,6 +10,12 @@ MODULE = (
 source = MODULE.read_text(encoding="utf-8")
 
 snippet = re.search(
+    r"BOLD_HEADING_RE.*?def _promote_bold_headings.*?return '\\n'.join\(out\)",
+    source,
+    re.S,
+).group()
+
+snippet2 = re.search(
     (
         r"HEADING_RE.*?def _normalize_headings.*?"
         r"return \"\\n\".join\(out\) \+ \"\\n\""
@@ -20,6 +26,8 @@ snippet = re.search(
 
 namespace = {"re": re}
 exec(snippet, namespace)
+exec(snippet2, namespace)
+_promote_bold_headings = namespace["_promote_bold_headings"]
 _normalize_headings = namespace["_normalize_headings"]
 
 
@@ -27,3 +35,9 @@ def test_normalize_headings_basic():
     text = "# H1\n\n\nPara\n\n## H2\n\nText\n"
     out = _normalize_headings(text)
     assert out == "# H1\nPara\n\n## H2\nText\n"
+
+
+def test_promote_bold_headings():
+    text = "Intro\n\n**SECTION**\nText"
+    out = _promote_bold_headings(text)
+    assert out == "Intro\n\n## SECTION\nText"


### PR DESCRIPTION
## Summary
- upgrade `convert_docx_to_md.py` to turn bold lines into `##` headings
- test new `_promote_bold_headings` helper

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3ec5a8648320b4bf8d711f3c33db