### PR TITLE
Fix missing dependencies in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install flake8 pytest
+        run: |
+          pip install -r project_meta/requirements.txt
+          pip install flake8 pytest
       - name: Lint
         run: flake8
       - name: Test


### PR DESCRIPTION
## Summary
- install project dependencies before running lints and tests

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d408e4fac832089bc34604b738fac