### PR TITLE
Remove redundant project_meta configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,36 +31,16 @@
 ## Folder Layout
 ```
 repo-root/
-│ README.md
-├── project_meta/
-│   ├── AGENTS.md
-│   ├── requirements.txt
-│   ├── .flake8
-│   ├── .gitignore
-│   └── pandoc-3.7.0.2-windows-x86_64.msi
+├── .github/
+├── .flake8
+├── .gitignore
 ├── 0. Config/
-│   ├── Structured_Input_scheme.json
-│   ├── modality_map.yaml
-│   └── query_configs.yaml
 ├── 1. Input/
-│   └── <vendor>.json
 ├── 2. Structured Input/
-│   ├── Structured Input Creator.py
-│   └── *.json
-└── 3. Report Generator/
-    ├── a. Prompts/
-    │   └── Templator Prompt.yaml
-    ├── b. Templates/
-    │   ├── convert_docx_to_md.py
-    │   ├── DOCX Source/
-    │   │   └── TEMPLATE *.docx
-    │   └── Text/
-    │       └── TEMPLATE *.md
-    ├── c. Generator/
-    │   ├── __init__.py
-    │   ├── cli.py
-    │   ├── gemini_reporter.py
-    │   └── select_assets.py
+├── 3. Report Generator/
+├── project_meta/
+├── tests/
+└── README.md
 ```
 
 ---

--- a/project_meta/.flake8
+++ b/project_meta/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 79
-exclude = .git,project_meta/pandoc-3.7.0.2-windows-x86_64.msi,0.*,1.*,3.*

--- a/project_meta/.gitignore
+++ b/project_meta/.gitignore
@@ -1,2 +1,0 @@
-__pycache__/
-*.py[cod]


### PR DESCRIPTION
## Summary
- delete `.flake8` and `.gitignore` from project_meta
- simplify folder layout in the README to list only root files

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2fb9eedc8320b4db1d022dc8d9bf