### PR TITLE
Add export utility

### DIFF
--- a/export_workflow.py
+++ b/export_workflow.py
@@ -51,13 +51,18 @@ def main() -> None:
         description="Copy pipeline artifacts to Downloads for traceability"
     )
     parser.add_argument(
-        "-o", "--output", type=Path, help="Output directory (default: Downloads)"
+        "-o",
+        "--output",
+        type=Path,
+        help="Output directory (default: Downloads)",
     )
     args = parser.parse_args()
 
     model = _load_model_name()
     ts = dt.datetime.now().strftime("%Y-%m-%d_%H-%M")
-    root_dir = (args.output or _downloads_dir()) / f"Therapixel Workflow_{model}_{ts}"
+    root_dir = (
+        args.output or _downloads_dir()
+    ) / f"Therapixel Workflow_{model}_{ts}"
     export(root_dir)
     print(f"Artifacts copied to {root_dir}")
 

--- a/tests/test_export_workflow.py
+++ b/tests/test_export_workflow.py
@@ -13,11 +13,17 @@ def setup_tmp(tmp_path):
     root.mkdir()
     cfg_dir = root / "0. Config"
     cfg_dir.mkdir()
-    (cfg_dir / "query_configs.yaml").write_text("model_name: test-model", encoding="utf-8")
+    (cfg_dir / "query_configs.yaml").write_text(
+        "model_name: test-model",
+        encoding="utf-8",
+    )
     (root / "1. Input").mkdir()
     (root / "1. Input" / "raw.json").write_text("{}", encoding="utf-8")
     (root / "2. Structured Input").mkdir()
-    (root / "2. Structured Input" / "struct.json").write_text("{}", encoding="utf-8")
+    (root / "2. Structured Input" / "struct.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
     tmpl_dir = root / "3. Report Generator" / "b. Templates" / "Text"
     tmpl_dir.mkdir(parents=True)
     (tmpl_dir / "t.md").write_text("T", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add `export_workflow.py` to gather raw inputs, structured inputs and all reports into a timestamped folder in the user's Downloads
- include regression test for the export helper

## Testing
- `pip install pyyaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e2fa310ac8320b20f6e802705397e