### PR TITLE
Add Gemini retry logic

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -139,24 +139,29 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         {"pre_report": structured, "templates": templates},
         ensure_ascii=False,
     )
-    resp = model.generate_content(
-        user_payload,
-        generation_config={
-            "temperature": cfg.get("temperature", 0.4),
-            "top_p": cfg.get("top_p", 0.8),
-            "max_output_tokens": cfg.get("max_output_tokens", 2048),
-        },
-    )
-    # `.text` can raise an exception when Gemini returns an empty candidate.
-    # Build the response text manually to handle safety blocks or other errors.
-    candidate = resp.candidates[0]
-    parts = getattr(candidate.content, "parts", [])
-    if not parts:
-        raise RuntimeError(
-            f"Gemini returned no content (finish_reason={candidate.finish_reason})"
+    retries = cfg.get("retries", 2)
+    last_reason = None
+    for attempt in range(retries + 1):
+        resp = model.generate_content(
+            user_payload,
+            generation_config={
+                "temperature": cfg.get("temperature", 0.4),
+                "top_p": cfg.get("top_p", 0.8),
+                "max_output_tokens": cfg.get("max_output_tokens", 2048),
+            },
         )
-    text = "".join(getattr(p, "text", str(p)) for p in parts)
-    return _parse_response(text)
+        candidate = resp.candidates[0]
+        parts = getattr(candidate.content, "parts", [])
+        if parts:
+            text = "".join(getattr(p, "text", str(p)) for p in parts)
+            return _parse_response(text)
+        last_reason = candidate.finish_reason
+        print(
+            f"[query_gemini] Empty response (finish_reason={last_reason}), retrying {attempt + 1}/{retries}",
+            flush=True,
+        )
+
+    raise RuntimeError(f"Gemini returned no content (finish_reason={last_reason})")
 
 
 def generate_reports(

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -1,0 +1,70 @@
+import importlib.util
+from pathlib import Path
+
+GEN_DIR = Path(__file__).resolve().parents[1] / '3. Report Generator' / 'c. Generator'
+MOD_PATH = GEN_DIR / 'gemini_reporter.py'
+spec = importlib.util.spec_from_file_location('reporter', MOD_PATH)
+reporter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reporter)
+
+
+class Part:
+    def __init__(self, text):
+        self.text = text
+
+
+class FakeModel:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def generate_content(self, *a, **kw):
+        self.calls += 1
+        return next(self.responses)
+
+
+def fake_candidate(parts=None, finish_reason=0):
+    class Content:
+        def __init__(self, parts):
+            self.parts = parts or []
+    class Candidate:
+        def __init__(self, parts, finish_reason):
+            self.content = Content(parts)
+            self.finish_reason = finish_reason
+    class Response:
+        def __init__(self, parts, finish_reason):
+            self.candidates = [Candidate(parts, finish_reason)]
+    return Response(parts, finish_reason)
+
+
+def common(monkeypatch):
+    monkeypatch.setattr(reporter, '_load_config', lambda: {'retries': 2})
+    monkeypatch.setattr(reporter, 'genai', type('G', (), {'configure': lambda *a, **k: None, 'GenerativeModel': lambda *a, **k: None}))
+
+
+def test_query_gemini_retries(monkeypatch):
+    common(monkeypatch)
+    responses = [
+        fake_candidate([], 2),
+        fake_candidate([], 2),
+        fake_candidate([Part('{"lines": ["ok"]}')], 0),
+    ]
+    model = FakeModel(responses)
+    monkeypatch.setattr(reporter, 'genai', type('G', (), {'configure': lambda *a, **k: None, 'GenerativeModel': lambda *a, **k: model}))
+    out = reporter.query_gemini({}, 'p', ['t'])
+    assert out == {'lines': ['ok']}
+    assert model.calls == 3
+
+
+def test_query_gemini_fail(monkeypatch):
+    common(monkeypatch)
+    responses = [fake_candidate([], 2), fake_candidate([], 2), fake_candidate([], 2)]
+    model = FakeModel(responses)
+    monkeypatch.setattr(reporter, 'genai', type('G', (), {'configure': lambda *a, **k: None, 'GenerativeModel': lambda *a, **k: model}))
+    try:
+        reporter.query_gemini({}, 'p', ['t'])
+    except RuntimeError as e:
+        assert 'no content' in str(e)
+    else:
+        assert False, 'expected RuntimeError'
+    assert model.calls == 3


### PR DESCRIPTION
## Summary
- add retry and debug logging to `query_gemini`
- test retry behavior of Gemini client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4c059d3883208d0f421eb6f52661