### PR TITLE
Add Gemini config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,16 @@ mammography:
 
 Example `query_configs.yaml`
 ```yaml
-model_name: models/gemini-1.5-pro-latest
+model_name: models/gemini-2.5-pro
 temperature: 0.4
 top_p: 0.1
 max_output_tokens: 6000
 prompt_file: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
+seed: 0                # reproducible tokens
+thinking_budget: 3000  # cap hidden reasoning tokens
+include_thoughts: true # add a reasoning block after the JSON
 ```
-Only the fields shown above are currently consumed by the code. Other keys like
-`include_thoughts`, `thinking_budget` and `seed` are legacy and can be ignored.
+The optional fields `seed` and `thinking_budget` are forwarded to Gemini's `generation_config`.
 
 ---
 

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -1,0 +1,141 @@
+import importlib.util
+from pathlib import Path
+
+GEN_DIR = (
+    Path(__file__).resolve().parents[1]
+    / '3. Report Generator'
+    / 'c. Generator'
+)
+MOD_PATH = GEN_DIR / 'gemini_reporter.py'
+spec = importlib.util.spec_from_file_location('reporter', MOD_PATH)
+reporter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(reporter)
+
+
+class Part:
+    def __init__(self, text):
+        self.text = text
+
+
+class FakeModel:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.calls = 0
+
+    def generate_content(self, *a, **kw):
+        self.calls += 1
+        return next(self.responses)
+
+
+def fake_candidate(parts=None, finish_reason=0):
+    class Content:
+        def __init__(self, parts):
+            self.parts = parts or []
+
+    class Candidate:
+        def __init__(self, parts, finish_reason):
+            self.content = Content(parts)
+            self.finish_reason = finish_reason
+
+    class Response:
+        def __init__(self, parts, finish_reason):
+            self.candidates = [Candidate(parts, finish_reason)]
+    return Response(parts, finish_reason)
+
+
+def common(monkeypatch):
+    monkeypatch.setattr(reporter, '_load_config', lambda: {'retries': 2})
+    monkeypatch.setattr(
+        reporter,
+        'genai',
+        type(
+            'G',
+            (),
+            {
+                'configure': lambda *a, **k: None,
+                'GenerativeModel': lambda *a, **k: None,
+            },
+        ),
+    )
+
+
+def test_query_gemini_retries(monkeypatch):
+    common(monkeypatch)
+    responses = [
+        fake_candidate([], 2),
+        fake_candidate([], 2),
+        fake_candidate([Part('{"lines": ["ok"]}')], 0),
+    ]
+    model = FakeModel(responses)
+    monkeypatch.setattr(
+        reporter,
+        'genai',
+        type(
+            'G',
+            (),
+            {
+                'configure': lambda *a, **k: None,
+                'GenerativeModel': lambda *a, **k: model,
+            },
+        ),
+    )
+    out = reporter.query_gemini({}, 'p', ['t'])
+    assert out == {'lines': ['ok']}
+    assert model.calls == 3
+
+
+def test_query_gemini_fail(monkeypatch):
+    common(monkeypatch)
+    responses = [
+        fake_candidate([], 2),
+        fake_candidate([], 2),
+        fake_candidate([], 2),
+    ]
+    model = FakeModel(responses)
+    monkeypatch.setattr(
+        reporter,
+        'genai',
+        type(
+            'G',
+            (),
+            {
+                'configure': lambda *a, **k: None,
+                'GenerativeModel': lambda *a, **k: model,
+            },
+        ),
+    )
+    try:
+        reporter.query_gemini({}, 'p', ['t'])
+    except RuntimeError as e:
+        assert 'no content' in str(e)
+    else:
+        assert False, 'expected RuntimeError'
+    assert model.calls == 3
+
+
+def test_generation_config(monkeypatch):
+    cfg = {"retries": 0, "seed": 123, "thinking_budget": 9}
+    monkeypatch.setattr(reporter, "_load_config", lambda: cfg)
+    captured = {}
+
+    class Model:
+        def generate_content(self, payload, generation_config=None):
+            captured.update(generation_config)
+            return fake_candidate([Part('{"lines": ["x"]}')], 0)
+
+    monkeypatch.setattr(
+        reporter,
+        "genai",
+        type(
+            "G",
+            (),
+            {
+                "configure": lambda *a, **k: None,
+                "GenerativeModel": lambda *a, **k: Model(),
+            },
+        ),
+    )
+    out = reporter.query_gemini({}, "p", ["t"])
+    assert out == {"lines": ["x"]}
+    assert captured["seed"] == 123
+    assert captured["thinkingBudget"] == 9


### PR DESCRIPTION
## Summary
- pass `seed` and `thinking_budget` from config to Gemini client
- document extra config fields in README
- test generation_config propagation

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_686e4c059d3883208d0f421eb6f52661