### PR TITLE
Remove Gemini seed config

### DIFF
--- a/0. Config/query_configs.yaml
+++ b/0. Config/query_configs.yaml
@@ -44,4 +44,3 @@ max_output_tokens: 6000
 prompt_file: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
 include_thoughts: true
 thinking_budget: 3000
-seed: 0

--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -146,10 +146,6 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         "top_p": cfg.get("top_p", 0.8),
         "max_output_tokens": cfg.get("max_output_tokens", 2048),
     }
-    if "seed" in cfg:
-        gen_cfg["seed"] = cfg["seed"]
-    if "thinking_budget" in cfg:
-        gen_cfg["thinkingBudget"] = cfg["thinking_budget"]
 
     for attempt in range(retries + 1):
         resp = model.generate_content(

--- a/README.md
+++ b/README.md
@@ -149,11 +149,10 @@ temperature: 0.4
 top_p: 0.1
 max_output_tokens: 6000
 prompt_file: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
-seed: 0                # reproducible tokens
 thinking_budget: 3000  # cap hidden reasoning tokens
 include_thoughts: true # add a reasoning block after the JSON
 ```
-The optional fields `seed` and `thinking_budget` are forwarded to Gemini's `generation_config`.
+
 
 ---
 

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -114,7 +114,7 @@ def test_query_gemini_fail(monkeypatch):
 
 
 def test_generation_config(monkeypatch):
-    cfg = {"retries": 0, "seed": 123, "thinking_budget": 9}
+    cfg = {"retries": 0}
     monkeypatch.setattr(reporter, "_load_config", lambda: cfg)
     captured = {}
 
@@ -137,5 +137,8 @@ def test_generation_config(monkeypatch):
     )
     out = reporter.query_gemini({}, "p", ["t"])
     assert out == {"lines": ["x"]}
-    assert captured["seed"] == 123
-    assert captured["thinkingBudget"] == 9
+    assert captured == {
+        "temperature": 0.4,
+        "top_p": 0.8,
+        "max_output_tokens": 2048,
+    }


### PR DESCRIPTION
## Summary
- drop unsupported `seed` and `thinking_budget` parameters
- update docs and config example
- adjust unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e57dd084c8320ada3fc9952699ebb