### PR TITLE
Add FAQ note about JSON mime type

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ pytest -q
 | `couldn't unpack docx container` | Source file isn’t real `.docx` – re‑save from Word or run the converter helper. |
 | Gemini `PermissionDenied` | Check API key and billing quota. |
 | Missing variables in output | Ensure prompt JSON names match Jinja placeholders. |
+| Gemini returns plain text instead of JSON | Add `response_mime_type: application/json` under `generationConfig` in `0. Config/query_configs.yaml`. |
 
 ---
 


### PR DESCRIPTION
## Summary
- document the `response_mime_type` workaround for Gemini models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6c2128bc8320b54dbcf22ffadf2f