### PR TITLE
Update gemini generation defaults and tests

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -145,6 +145,7 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         "temperature": 0.4,
         "top_p": 0.8,
         "max_output_tokens": 2048,
+        "response_mime_type": "application/json",
     }
     gcfg = cfg.get("generationConfig") or cfg.get("generation_config") or {}
     gen_cfg = {
@@ -156,7 +157,17 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         ),
         "max_output_tokens": gcfg.get(
             "maxOutputTokens",
-            gcfg.get("max_output_tokens", cfg.get("max_output_tokens", defaults["max_output_tokens"])),
+            gcfg.get(
+                "max_output_tokens",
+                cfg.get("max_output_tokens", defaults["max_output_tokens"]),
+            ),
+        ),
+        "response_mime_type": gcfg.get(
+            "responseMimeType",
+            gcfg.get(
+                "response_mime_type",
+                cfg.get("response_mime_type", defaults["response_mime_type"]),
+            ),
         ),
     }
 

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -141,6 +141,7 @@ def test_generation_config(monkeypatch):
         "temperature": 0.4,
         "top_p": 0.8,
         "max_output_tokens": 2048,
+        "response_mime_type": "application/json",
     }
 
 
@@ -179,4 +180,5 @@ def test_generation_config_nested(monkeypatch):
         "temperature": 0.7,
         "top_p": 0.3,
         "max_output_tokens": 999,
+        "response_mime_type": "application/json",
     }


### PR DESCRIPTION
## Summary
- default Gemini responses are JSON
- expect `response_mime_type` in generation config tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6c1d2cc88320b11003e1910c975d