### PR TITLE
Add response MIME type setting

### DIFF
--- a/0. Config/query_configs.yaml
+++ b/0. Config/query_configs.yaml
@@ -43,6 +43,7 @@ generationConfig:
   temperature: 0.4
   topP: 0.1
   maxOutputTokens: 6000
+  response_mime_type: application/json
 thinkingConfig:
   includeThoughts: true           # summaries only
   thinkingBudget: 3000

--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -159,6 +159,10 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
             gcfg.get("max_output_tokens", cfg.get("max_output_tokens", defaults["max_output_tokens"])),
         ),
     }
+    gen_cfg["response_mime_type"] = gcfg.get(
+        "response_mime_type",
+        cfg.get("response_mime_type", "application/json"),
+    )
 
     for attempt in range(retries + 1):
         resp = model.generate_content(

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ pandoc report.md -o report.docx   --reference-doc="3. Report Generator/b. Templa
 |------|---------|
 | **Structured_Input_scheme.json** | JSON schema enforced by step 2. |
 | **modality_map.yaml** | Maps `modality` → `{prompt, templates}`. |
-| **query_configs.yaml** | Model, temperature, prompt file, max‑tokens, etc. |
+| **query_configs.yaml** | Model, temperature, prompt file, max‑tokens, response type, etc. |
 
 Example `modality_map.yaml`
 ```yaml
@@ -149,6 +149,7 @@ generationConfig:
   temperature: 0.4
   topP: 0.1
   maxOutputTokens: 6000
+  response_mime_type: application/json
 prompt_file: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
 thinkingConfig:
   thinkingBudget: 3000  # cap hidden reasoning tokens

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -141,6 +141,7 @@ def test_generation_config(monkeypatch):
         "temperature": 0.4,
         "top_p": 0.8,
         "max_output_tokens": 2048,
+        "response_mime_type": "application/json",
     }
 
 
@@ -179,4 +180,5 @@ def test_generation_config_nested(monkeypatch):
         "temperature": 0.7,
         "top_p": 0.3,
         "max_output_tokens": 999,
+        "response_mime_type": "application/json",
     }


### PR DESCRIPTION
## Summary
- support `response_mime_type` in configuration
- default Gemini requests to `application/json`
- document the new configuration option
- expect `response_mime_type` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6c13a880832082a549d44ee334a9