### PR TITLE
Validate Gemini response

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -147,7 +147,17 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
             "max_output_tokens": cfg.get("max_output_tokens", 2048),
         },
     )
-    return _parse_response(resp.text)
+
+    feedback = getattr(resp, "prompt_feedback", None)
+    if feedback and getattr(feedback, "block_reason", 0):
+        raise RuntimeError(str(feedback))
+
+    try:
+        text = resp.text
+    except Exception as exc:  # pragma: no cover - network errors
+        raise RuntimeError(str(exc))
+
+    return _parse_response(text)
 
 
 def generate_reports(


### PR DESCRIPTION
## Summary
- check Gemini response for blocked reasons
- only parse when model output is present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e74d4276483209416a3b2e1bb92f0