### PR TITLE
Add debug output for Gemini parse errors

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -196,7 +196,14 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         parts = getattr(candidate.content, "parts", [])
         if parts:
             text = "".join(getattr(p, "text", str(p)) for p in parts)
-            return _parse_response(text)
+            try:
+                return _parse_response(text)
+            except ValueError:
+                print(
+                    "[query_gemini] Unparsable response from Gemini:\n" + text,
+                    flush=True,
+                )
+                raise
         last_reason = candidate.finish_reason
         print(
             f"[query_gemini] Empty response (finish_reason={last_reason}), retrying {attempt + 1}/{retries}",


### PR DESCRIPTION
## Summary
- show the Gemini raw response text when parsing fails

## Testing
- `pip install -r project_meta/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8eadf4148320b8ec2eb4557de8c2