### PR TITLE
Update MD workflow defaults

### DIFF
--- a/3. Report Generator/c. Generator/gemini_reporter.py
+++ b/3. Report Generator/c. Generator/gemini_reporter.py
@@ -59,7 +59,7 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
         "temperature": 0.4,
         "top_p": 0.8,
         "max_output_tokens": 2048,
-        "response_mime_type": "application/json",
+        "response_mime_type": "text/plain",
     }
     gcfg = cfg.get("generationConfig") or cfg.get("generation_config") or {}
     gen_cfg = {
@@ -86,7 +86,7 @@ def query_gemini(structured: Dict[str, Any], prompt: str, templates: List[str]) 
     }
     gen_cfg["response_mime_type"] = gcfg.get(
         "response_mime_type",
-        cfg.get("response_mime_type", "application/json"),
+        cfg.get("response_mime_type", defaults["response_mime_type"]),
     )
 
     for attempt in range(retries + 1):
@@ -140,7 +140,7 @@ def generate_reports(
         text = query_gemini(structured, prompt, [template_text])
         if json_dir is not None:
             json_dir.mkdir(parents=True, exist_ok=True)
-            (json_dir / f"{path.stem}.json").write_text(text, encoding="utf-8")
+            (json_dir / f"{path.stem}.md").write_text(text, encoding="utf-8")
         reports[path.stem] = text
 
     return reports

--- a/export_workflow.py
+++ b/export_workflow.py
@@ -47,6 +47,7 @@ def export(dest: Path) -> None:
     _copy_tree(JSONS, reports / "b. Gemini MDs")
     _copy_tree(FINAL_MD, reports / "c. Final MD")
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Copy pipeline artifacts to Downloads for traceability"

--- a/tests/test_export_workflow.py
+++ b/tests/test_export_workflow.py
@@ -1,6 +1,5 @@
 import importlib.util
 from pathlib import Path
-import json
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "export_workflow.py"
 spec = importlib.util.spec_from_file_location("exp", MODULE_PATH)

--- a/tests/test_export_workflow.py
+++ b/tests/test_export_workflow.py
@@ -50,11 +50,11 @@ def test_export(tmp_path):
 
     exp.export(out)
 
-    assert (out / "1. Raw Therapixel Inputs" / "raw.json").exists()
-    assert (out / "2. Structured Inputs" / "struct.json").exists()
-    assert (out / "3. Reports" / "a. Templates" / "t.md").exists()
-    assert (out / "3. Reports" / "b. Gemini MDs" / "r.md").exists()
-    assert (out / "3. Reports" / "c. Final MD" / "f.md").exists()
+    assert (out / "Raw Therapixel Inputs" / "raw.json").exists()
+    assert (out / "Structured Inputs" / "struct.json").exists()
+    assert (out / "Reports" / "a. Templates" / "t.md").exists()
+    assert (out / "Reports" / "b. Gemini MDs" / "r.md").exists()
+    assert (out / "Reports" / "c. Final MD" / "f.md").exists()
 
 
 def test_model_name(tmp_path):

--- a/tests/test_generate_reports.py
+++ b/tests/test_generate_reports.py
@@ -52,10 +52,10 @@ def test_generate_reports_json_dir(monkeypatch, tmp_path):
     prompt.write_text("prompt")
     t1 = tmp_path / "a.md"
     t1.write_text("T")
-    jdir = tmp_path / "json"
+    jdir = tmp_path / "md"
 
     result = renderer.generate_reports({}, prompt, [t1], json_dir=jdir)
 
     assert result == {"a": "res"}
-    saved = (jdir / "a.json").read_text()
+    saved = (jdir / "a.md").read_text()
     assert saved == output

--- a/tests/test_query_gemini.py
+++ b/tests/test_query_gemini.py
@@ -141,7 +141,7 @@ def test_generation_config(monkeypatch):
         "temperature": 0.4,
         "top_p": 0.8,
         "max_output_tokens": 2048,
-        "response_mime_type": "application/json",
+        "response_mime_type": "text/plain",
     }
 
 
@@ -180,5 +180,5 @@ def test_generation_config_nested(monkeypatch):
         "temperature": 0.7,
         "top_p": 0.3,
         "max_output_tokens": 999,
-        "response_mime_type": "application/json",
+        "response_mime_type": "text/plain",
     }


### PR DESCRIPTION
## Summary
- tweak export workflow test paths
- expect plain text from Gemini
- store raw report outputs with `.md` extension

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b16726208320b036e846c3ecc3b3