### PR TITLE
Fix template path to Markdown folder

### DIFF
--- a/0. Config/modality_map.yaml
+++ b/0. Config/modality_map.yaml
@@ -1,3 +1,3 @@
 mammography:
   prompt: 3. Report Generator/a. Prompts/Templator Prompt - Modified for Mammo.yaml
-  templates: 3. Report Generator/b. Templates/Text
+  templates: 3. Report Generator/b. Templates/Markdown

--- a/3. Report Generator/b. Templates/convert_docx_to_md.py
+++ b/3. Report Generator/b. Templates/convert_docx_to_md.py
@@ -5,7 +5,7 @@ convert_docx_to_md.py
 Batch-convert every Word template under
   3. Report Generator/b. Templates/DOCX Source/
 into UTF-8 Markdown files in
-  3. Report Generator/b. Templates/Text/
+  3. Report Generator/b. Templates/Markdown/
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from pathlib import Path
 # ── Locate folders ────────────────────────────────────────────────────────────
 ROOT     = Path(__file__).resolve().parent
 DOCX_DIR = ROOT / "DOCX Source"
-MD_DIR  = ROOT / "Text"
+MD_DIR  = ROOT / "Markdown"
 
 # ── Find or download Pandoc ───────────────────────────────────────────────────
 def ensure_pandoc() -> str:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ python export_workflow.py
 ### 2️⃣  Select assets  
 `select_assets.py` looks up **modality_map.yaml** to pair each case with:
 * a system prompt (`a. Prompts/…`)
-* a text template (`b. Templates/Text/…`)
+* a Markdown template (`b. Templates/Markdown/…`)
 
 This mapping file is required by the batch CLI; removing it will result in
 errors when generating reports.
@@ -121,7 +121,7 @@ pandoc report.md -o report.docx   --reference-doc="3. Report Generator/b. Templa
 | Asset | Edited by | Location |
 |-------|-----------|----------|
 | **Word master templates** | Radiologists | `b. Templates/DOCX Source/*.docx` |
-| **Text templates** | Devs + radiologists familiar with Git | `b. Templates/Text/*.md` |
+| **Markdown templates** | Devs + radiologists familiar with Git | `b. Templates/Markdown/*.md` |
 | **System prompts** | Prompt‑engineer | `a. Prompts/*.yaml` |
 
 **Add a new template**
@@ -144,7 +144,7 @@ Example `modality_map.yaml`
 ```yaml
 mammography:
   prompt: 3. Report Generator/a. Prompts/Templator Prompt.yaml  # overridden by query_configs.yaml
-  templates: 3. Report Generator/b. Templates/Text
+  templates: 3. Report Generator/b. Templates/Markdown
 ```
 
 Example `query_configs.yaml`

--- a/export_workflow.py
+++ b/export_workflow.py
@@ -13,7 +13,7 @@ CONFIG = ROOT / "0. Config" / "query_configs.yaml"
 
 RAW_INPUTS = ROOT / "1. Input"
 STRUCTURED_INPUTS = ROOT / "2. Structured Input"
-TEMPLATES = ROOT / "3. Report Generator" / "b. Templates" / "Text"
+TEMPLATES = ROOT / "3. Report Generator" / "b. Templates" / "Markdown"
 JSONS = ROOT / "3. Report Generator" / "d. Gemini Output MD"
 
 

--- a/tests/test_export_workflow.py
+++ b/tests/test_export_workflow.py
@@ -23,7 +23,7 @@ def setup_tmp(tmp_path):
         "{}",
         encoding="utf-8",
     )
-    tmpl_dir = root / "3. Report Generator" / "b. Templates" / "Text"
+    tmpl_dir = root / "3. Report Generator" / "b. Templates" / "Markdown"
     tmpl_dir.mkdir(parents=True)
     (tmpl_dir / "t.md").write_text("T", encoding="utf-8")
     json_dir = root / "3. Report Generator" / "d. Gemini Output MD"
@@ -40,7 +40,7 @@ def test_export(tmp_path):
     exp.CONFIG = root / "0. Config" / "query_configs.yaml"
     exp.RAW_INPUTS = root / "1. Input"
     exp.STRUCTURED_INPUTS = root / "2. Structured Input"
-    exp.TEMPLATES = root / "3. Report Generator" / "b. Templates" / "Text"
+    exp.TEMPLATES = root / "3. Report Generator" / "b. Templates" / "Markdown"
     exp.JSONS = root / "3. Report Generator" / "d. Gemini Output MD"
 
     exp.export(out)


### PR DESCRIPTION
## Summary
- rename `Text` folder references to `Markdown`
- update config, README, and helper scripts
- adjust tests for new path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877c1fd25d883208c65819b964f83c9